### PR TITLE
Add pytest tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,12 @@ For complete guides and SDK information see [docs.bondmcp.com](https://docs.bond
 ## API Overview
 
 See [API_OVERVIEW.md](./API_OVERVIEW.md) for a summary of available endpoints. Always check the link above for the most up-to-date schema.
+
+## Running Tests
+
+Install the optional test dependencies and run `pytest`:
+
+```bash
+pip install -e .[test]
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,8 @@ dependencies = [
 
 [project.scripts]
 bondmcp-cli = "bondmcp_cli.cli:cli"
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7",
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,55 @@
+import sys
+import types
+from pathlib import Path
+
+# Ensure the project root is on the path when running tests directly
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+# Provide stub modules for dependencies that aren't installed in the test
+# environment.
+requests_stub = types.ModuleType("requests")
+requests_stub.post = lambda *a, **k: None
+sys.modules["requests"] = requests_stub
+
+rich = types.ModuleType("rich")
+rich_console = types.ModuleType("rich.console")
+class DummyConsole:
+    def print(self, *args, **kwargs):
+        print(*args)
+rich_console.Console = DummyConsole
+rich.console = rich_console
+sys.modules.setdefault("rich", rich)
+sys.modules.setdefault("rich.console", rich_console)
+
+from click.testing import CliRunner
+from bondmcp_cli.cli import ask
+
+class DummyResp:
+    def __init__(self, status_code, json_data=None, text=""):
+        self.status_code = status_code
+        self._json_data = json_data or {}
+        self.text = text
+    def json(self):
+        return self._json_data
+
+
+def test_ask_success(monkeypatch):
+    def mock_post(url, json, headers):
+        return DummyResp(200, {"response": "hello"})
+    monkeypatch.setattr("bondmcp_cli.cli.requests.post", mock_post)
+    monkeypatch.setattr("bondmcp_cli.cli.get_api_key", lambda: "key")
+    runner = CliRunner()
+    result = runner.invoke(ask, ["hi"])
+    assert result.exit_code == 0
+    assert "hello" in result.output
+
+
+def test_ask_error(monkeypatch):
+    def mock_post(url, json, headers):
+        return DummyResp(500, text="fail")
+    monkeypatch.setattr("bondmcp_cli.cli.requests.post", mock_post)
+    monkeypatch.setattr("bondmcp_cli.cli.get_api_key", lambda: "key")
+    runner = CliRunner()
+    result = runner.invoke(ask, ["hi"])
+    assert result.exit_code == 1
+    assert "API error 500: fail" in result.output

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,91 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+# Ensure the project root is on the path when running tests directly
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import pytest
+
+# Provide a minimal stub of the requests library since it isn't available in the
+# execution environment.
+class HTTPError(Exception):
+    def __init__(self, *args, response=None, **kwargs):
+        super().__init__(*args)
+        self.response = response
+
+class ConnectionError(Exception):
+    pass
+
+class Timeout(Exception):
+    pass
+
+class RequestException(Exception):
+    pass
+
+requests_stub = types.ModuleType("requests")
+requests_stub.exceptions = types.SimpleNamespace(
+    HTTPError=HTTPError,
+    ConnectionError=ConnectionError,
+    Timeout=Timeout,
+    RequestException=RequestException,
+)
+requests_stub.get = lambda *a, **k: None
+requests_stub.post = lambda *a, **k: None
+sys.modules["requests"] = requests_stub
+requests = requests_stub
+
+spec = importlib.util.spec_from_file_location(
+    "bondmcp_python", Path(__file__).resolve().parents[1] / "sdk" / "bondmcp-python.py"
+)
+bondmcp_python = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bondmcp_python)
+
+BondMCPClient = bondmcp_python.BondMCPClient
+BondMCPAPIError = bondmcp_python.BondMCPAPIError
+
+
+class MockResponse:
+    def __init__(self, json_data=None, status_code=200, exc=None):
+        self._json = json_data or {}
+        self.status_code = status_code
+        self.exc = exc
+        self.text = "err"
+
+    def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.exc:
+            raise self.exc
+
+
+def test_request_success(monkeypatch):
+    client = BondMCPClient("k", base_url="https://example.com")
+
+    def mock_get(url, headers=None, params=None, timeout=None):
+        return MockResponse({"ok": True})
+
+    monkeypatch.setattr(bondmcp_python.requests, "get", mock_get)
+    assert client.request("get", "/health") == {"ok": True}
+
+
+def test_request_http_error(monkeypatch):
+    client = BondMCPClient("k")
+
+    def mock_post(url, headers=None, json=None, timeout=None):
+        resp = MockResponse({"error": {"message": "bad", "code": "bad", "details": {"a": 1}}}, status_code=400)
+        error = requests.exceptions.HTTPError(response=resp)
+        resp.exc = error
+        return resp
+
+    monkeypatch.setattr(bondmcp_python.requests, "post", mock_post)
+
+    with pytest.raises(BondMCPAPIError) as exc:
+        client.request("post", "/test")
+
+    err = exc.value
+    assert err.status_code == 400
+    assert err.code == "bad"
+    assert err.details == {"a": 1}
+    assert str(err) == "bad"


### PR DESCRIPTION
## Summary
- add test directory with pytest-based tests
- support pytest install via optional dependencies
- document running tests in README

## Testing
- `pytest -q`
