### PR TITLE
Add Node SDK package

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,29 @@ bondmcp-cli ask "What can BondMCP do?"
 
 The CLI uses `BONDMCP_PUBLIC_API_BASE_URL` if you need to target a different host (defaults to `https://api.bondmcp.com`).
 
+## Node SDK
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Create a client and call an endpoint:
+
+```javascript
+const BondMCPClient = require('./sdk/bondmcp-node');
+
+const client = new BondMCPClient('YOUR_API_KEY');
+
+async function main() {
+  const health = await client.health.check();
+  console.log(health);
+}
+
+main();
+```
+
 ## API Reference
 
 The latest OpenAPI schema is available at [api.bondmcp.com/openapi.json](https://api.bondmcp.com/openapi.json).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bondmcp-node-sdk",
+  "version": "0.1.0",
+  "main": "sdk/bondmcp-node.js",
+  "dependencies": {
+    "axios": "^1.6.0"
+  }
+}

--- a/sdk/bondmcp-node.js
+++ b/sdk/bondmcp-node.js
@@ -194,9 +194,7 @@ class BondMCPNetworkError extends BondMCPError {
   }
 }
 
-module.exports = {
-  Client: BondMCPClient,
-  APIError: BondMCPAPIError,
-  NetworkError: BondMCPNetworkError,
-  Error: BondMCPError
-};
+module.exports = BondMCPClient;
+module.exports.APIError = BondMCPAPIError;
+module.exports.NetworkError = BondMCPNetworkError;
+module.exports.Error = BondMCPError;


### PR DESCRIPTION
## Summary
- add `package.json` for the Node SDK
- export the Node client class directly
- document installation and example usage of the Node SDK in README

## Testing
- `git status --short`