### PR TITLE
Use keyring for API key storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Generate an API key from the [developer portal](https://api.bondmcp.com) and exp
 export BONDMCP_PUBLIC_API_KEY=your_key
 ```
 
-If the environment variable is omitted, the CLI will ask for the key the first
-time it runs and save it to `~/.bondmcp_cli` for future use.
+If the environment variable is omitted, the CLI will prompt for the key the first
+time it runs and store it using your system keyring for future use (when available).
 
 ## Using the CLI
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ requires-python = ">=3.8"
 dependencies = [
     "click>=8.0",
     "requests>=2.25",
-    "rich>=13.0"
+    "rich>=13.0",
+    "keyring>=23.0"
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- secure API key management using `keyring`
- update docs for new behaviour
- declare `keyring` dependency

## Testing
- `python3 -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*