### PR TITLE
Add CLI commands for more endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,24 @@ Send a question to the API:
 bondmcp-cli ask "What can BondMCP do?"
 ```
 
+Interpret lab results:
+
+```bash
+bondmcp-cli labs-interpret labs.json --context patient.json
+```
+
+Get supplement recommendations:
+
+```bash
+bondmcp-cli supplement-recommend fitness --labs labs.json --current-supplements current.json
+```
+
+Check API status:
+
+```bash
+bondmcp-cli health
+```
+
 The CLI uses `BONDMCP_PUBLIC_API_BASE_URL` if you need to target a different host (defaults to `https://api.bondmcp.com`).
 
 ## API Reference

--- a/bondmcp_cli/cli.py
+++ b/bondmcp_cli/cli.py
@@ -50,13 +50,108 @@ def cli():
 @cli.command()
 @click.argument("query")
 def ask(query):
-    """Send a query to the BondMCP /ask endpoint."""
+    """Send a question to the `/ask` endpoint."""
     api_key = get_api_key()
     base_url = os.getenv("BONDMCP_PUBLIC_API_BASE_URL", "https://api.bondmcp.com")
     url = f"{base_url}/ask"
-    resp = requests.post(url, json={"query": query}, headers={"Authorization": f"Bearer {api_key}"})
+    resp = requests.post(
+        url,
+        json={"query": query},
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
     if resp.status_code == 200:
         Console().print(resp.json().get("response"))
+    else:
+        Console().print(f"API error {resp.status_code}: {resp.text}")
+        raise SystemExit(1)
+
+
+@cli.command(name="labs-interpret")
+@click.argument("labs", type=click.Path(exists=True))
+@click.option(
+    "--context",
+    type=click.Path(exists=True),
+    help="Optional JSON file with patient context information.",
+)
+def labs_interpret(labs, context):
+    """Interpret lab results via `/labs/interpret`."""
+    api_key = get_api_key()
+    base_url = os.getenv("BONDMCP_PUBLIC_API_BASE_URL", "https://api.bondmcp.com")
+    url = f"{base_url}/labs/interpret"
+
+    payload = {"lab_results": json.loads(Path(labs).read_text())}
+    if context:
+        payload["patient_context"] = json.loads(Path(context).read_text())
+
+    resp = requests.post(url, json=payload, headers={"Authorization": f"Bearer {api_key}"})
+    if resp.status_code == 200:
+        Console().print_json(data=resp.json())
+    else:
+        Console().print(f"API error {resp.status_code}: {resp.text}")
+        raise SystemExit(1)
+
+
+@cli.command(name="supplement-recommend")
+@click.argument("health_goals", nargs=-1)
+@click.option(
+    "--labs",
+    type=click.Path(exists=True),
+    help="Path to JSON file with current lab results.",
+)
+@click.option(
+    "--current-supplements",
+    type=click.Path(exists=True),
+    help="JSON file with a list of current supplements.",
+)
+@click.option(
+    "--dietary-restrictions",
+    type=click.Path(exists=True),
+    help="JSON file with dietary restrictions.",
+)
+@click.option(
+    "--context",
+    type=click.Path(exists=True),
+    help="Optional JSON file with patient context.",
+)
+def supplement_recommend(
+    health_goals,
+    labs,
+    current_supplements,
+    dietary_restrictions,
+    context,
+):
+    """Get supplement recommendations via `/supplement/recommend`."""
+    api_key = get_api_key()
+    base_url = os.getenv("BONDMCP_PUBLIC_API_BASE_URL", "https://api.bondmcp.com")
+    url = f"{base_url}/supplement/recommend"
+
+    payload = {"health_goals": list(health_goals)}
+    if labs:
+        payload["current_labs"] = json.loads(Path(labs).read_text())
+    if current_supplements:
+        payload["current_supplements"] = json.loads(Path(current_supplements).read_text())
+    if dietary_restrictions:
+        payload["dietary_restrictions"] = json.loads(Path(dietary_restrictions).read_text())
+    if context:
+        payload["patient_context"] = json.loads(Path(context).read_text())
+
+    resp = requests.post(url, json=payload, headers={"Authorization": f"Bearer {api_key}"})
+    if resp.status_code == 200:
+        Console().print_json(data=resp.json())
+    else:
+        Console().print(f"API error {resp.status_code}: {resp.text}")
+        raise SystemExit(1)
+
+
+@cli.command()
+def health():
+    """Check API health via `/health`."""
+    api_key = get_api_key()
+    base_url = os.getenv("BONDMCP_PUBLIC_API_BASE_URL", "https://api.bondmcp.com")
+    url = f"{base_url}/health"
+    resp = requests.get(url, headers={"Authorization": f"Bearer {api_key}"})
+    if resp.status_code == 200:
+        Console().print_json(data=resp.json())
     else:
         Console().print(f"API error {resp.status_code}: {resp.text}")
         raise SystemExit(1)


### PR DESCRIPTION
## Summary
- add `labs-interpret`, `supplement-recommend` and `health` commands
- update README with examples for new commands

## Testing
- `python -m py_compile bondmcp_cli/cli.py`
- `python -m py_compile sdk/bondmcp-python.py`
