### PR TITLE
Write config file securely

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ export BONDMCP_PUBLIC_API_KEY=your_key
 ```
 
 If the environment variable is omitted, the CLI will ask for the key the first
-time it runs and save it to `~/.bondmcp_cli` for future use.
+time it runs and save it to `~/.bondmcp_cli` for future use. The file is created
+with permissions `600` so that only your user can read and write the stored key.
 
 ## Using the CLI
 

--- a/bondmcp_cli/cli.py
+++ b/bondmcp_cli/cli.py
@@ -36,7 +36,13 @@ def get_api_key() -> str:
     # Prompt user for key and store for future use
     api_key = click.prompt("Enter your BondMCP public API key", hide_input=True)
     try:
-        CONFIG_FILE.write_text(json.dumps({"api_key": api_key}))
+        fd = os.open(
+            str(CONFIG_FILE),
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+            0o600,
+        )
+        with os.fdopen(fd, "w") as f:
+            f.write(json.dumps({"api_key": api_key}))
     except Exception:
         pass
     return api_key


### PR DESCRIPTION
## Summary
- make sure stored API key file is created with 600 permissions
- mention file privacy in README

## Testing
- `pytest -q`
- manual check of created file permissions