### PR TITLE
Use keyring for API key storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ export BONDMCP_PUBLIC_API_KEY=your_key
 ```
 
 If the environment variable is omitted, the CLI will ask for the key the first
-time it runs and save it to `~/.bondmcp_cli` for future use.
+time it runs and store it securely using your system keyring. If keyring is not
+available, you must set `BONDMCP_PUBLIC_API_KEY` each time.
 
 ## Using the CLI
 

--- a/bondmcp_cli/cli.py
+++ b/bondmcp_cli/cli.py
@@ -1,44 +1,39 @@
-import json
 import os
-from pathlib import Path
+
+try:
+    import keyring
+except Exception:  # pragma: no cover - optional dependency may be missing
+    keyring = None
 
 import click
 import requests
 from rich.console import Console
 
-# Path to store the API key if provided interactively
-CONFIG_FILE = Path.home() / ".bondmcp_cli"
-
 
 def get_api_key() -> str:
-    """Retrieve the API key from env or interactive prompt.
-
-    Priority order:
-    1. BONDMCP_PUBLIC_API_KEY environment variable
-    2. Stored key in CONFIG_FILE
-    3. Interactive prompt asking the user
-    """
+    """Retrieve the API key from env, keyring or interactive prompt."""
 
     env_key = os.getenv("BONDMCP_PUBLIC_API_KEY")
     if env_key:
         return env_key
 
-    if CONFIG_FILE.exists():
+    if keyring is not None:
         try:
-            data = json.loads(CONFIG_FILE.read_text())
-            stored_key = data.get("api_key")
+            stored_key = keyring.get_password("bondmcp_cli", "api_key")
             if stored_key:
                 return stored_key
         except Exception:
             # ignore errors and fallback to prompt
             pass
 
-    # Prompt user for key and store for future use
     api_key = click.prompt("Enter your BondMCP public API key", hide_input=True)
-    try:
-        CONFIG_FILE.write_text(json.dumps({"api_key": api_key}))
-    except Exception:
-        pass
+
+    if keyring is not None:
+        try:
+            keyring.set_password("bondmcp_cli", "api_key", api_key)
+        except Exception:
+            pass
+
     return api_key
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,8 @@ requires-python = ">=3.8"
 dependencies = [
     "click>=8.0",
     "requests>=2.25",
-    "rich>=13.0"
+    "rich>=13.0",
+    "keyring>=23.13"
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- avoid plaintext key storage and use keyring library
- store API key securely via keyring
- update README to explain behaviour
- add keyring dependency

## Testing
- `python -m py_compile bondmcp_cli/cli.py`
- `pytest -q`