### PR TITLE
Add Node SDK package and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,25 @@ bondmcp-cli ask "What can BondMCP do?"
 
 The CLI uses `BONDMCP_PUBLIC_API_BASE_URL` if you need to target a different host (defaults to `https://api.bondmcp.com`).
 
+## Node.js SDK
+
+A minimal Node.js client is provided in `sdk/bondmcp-node.js`.
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Example usage:
+
+```javascript
+const BondMCPClient = require('./sdk/bondmcp-node');
+
+const client = new BondMCPClient('your_api_key');
+client.health.check().then(console.log);
+```
+
 ## API Reference
 
 The latest OpenAPI schema is available at [api.bondmcp.com/openapi.json](https://api.bondmcp.com/openapi.json).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "bondmcp-node",
+  "version": "1.0.0",
+  "main": "sdk/bondmcp-node.js",
+  "dependencies": {
+    "axios": "^1.6.0"
+  }
+}

--- a/sdk/bondmcp-node.js
+++ b/sdk/bondmcp-node.js
@@ -194,9 +194,7 @@ class BondMCPNetworkError extends BondMCPError {
   }
 }
 
-module.exports = {
-  Client: BondMCPClient,
-  APIError: BondMCPAPIError,
-  NetworkError: BondMCPNetworkError,
-  Error: BondMCPError
-};
+module.exports = BondMCPClient;
+module.exports.APIError = BondMCPAPIError;
+module.exports.NetworkError = BondMCPNetworkError;
+module.exports.Error = BondMCPError;


### PR DESCRIPTION
## Summary
- create `package.json` for the Node.js SDK
- export the client class from `bondmcp-node.js`
- document installation and basic usage for the Node SDK

## Testing
- `pytest -q`