### PR TITLE
Add .env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# BondMCP configuration
+# Copy this file to .env and set your credentials
+BONDMCP_PUBLIC_API_KEY=your-api-key
+# Optional: change the API base URL
+BONDMCP_PUBLIC_API_BASE_URL=https://api.bondmcp.com

--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ const response = await client.ask({
 
 console.log(response.answer);
 ```
+### Environment Setup
+
+Copy `.env.example` to `.env` and provide your API key before using the CLI or SDK.
+
+```bash
+cp .env.example .env
+```
+
+Edit `.env` and set `BONDMCP_PUBLIC_API_KEY` and optional `BONDMCP_PUBLIC_API_BASE_URL`.
 
 ## Features
 


### PR DESCRIPTION
## Summary
- add `.env.example` with required configuration variables
- document setup instructions in the README referencing this file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6846130518348332a8f36141bc1e3ee6