### PR TITLE
Update package install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,19 @@ BondMCP provides a healthcare-optimized implementation of the Model Context Prot
 ### Installation
 
 ```bash
-npm install @bondmcp/sdk
+npm install @bondmcp/typescript-sdk
 # or
-pip install bondmcp-sdk
+pip install bondmcp
 ```
+
+The Python package was previously published as `bondmcp-sdk`. That legacy name
+is still available on PyPI but is no longer maintained. Use `bondmcp` for new
+projects.
 
 ### Basic Usage
 
 ```javascript
-import { BondMCPClient } from '@bondmcp/sdk';
+import { BondMCPClient } from '@bondmcp/typescript-sdk';
 
 const client = new BondMCPClient({
   apiKey: 'your-api-key',

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -8,6 +8,10 @@ The BondMCP Python SDK provides a simple and intuitive interface to integrate Bo
 pip install bondmcp
 ```
 
+> **Note**: A legacy package named `bondmcp-sdk` exists on PyPI. It is no longer
+> updated and should only be used for backwards compatibility. New applications
+> should depend on the `bondmcp` package shown above.
+
 ## Quick Start
 
 ```python

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -27,6 +27,11 @@ yarn add @bondmcp/typescript-sdk
 pnpm add @bondmcp/typescript-sdk
 ```
 
+> **Note**: A basic Node.js client is available in this repository as
+> `bondmcp-node-sdk`. It provides minimal functionality and is primarily kept for
+> compatibility with older examples. For new projects we recommend using the
+> fully featured `@bondmcp/typescript-sdk` package described above.
+
 ## Quick Start
 
 ```typescript


### PR DESCRIPTION
## Summary
- clarify that `@bondmcp/typescript-sdk` and `bondmcp` are the recommended packages
- highlight the legacy `bondmcp-sdk` and `bondmcp-node-sdk`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68461303baf483329540a83d4a9cb539