### PR TITLE
Add pre-commit config and integrate with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,9 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .
-          pip install pytest
+          pip install .[dev]
+      - name: Run pre-commit
+        run: pre-commit run --all-files
       - name: Run Python tests
         run: pytest -v
       - uses: actions/setup-node@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,6 @@ jobs:
         with:
           python-version: '3.x'
       - run: python -m pip install --upgrade pip
-      - run: pip install -e .
-      - run: pip install pytest
+      - run: pip install -e .[dev]
+      - run: pre-commit run --all-files
       - run: pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.8.0
+    hooks:
+      - id: mypy
+        args: ["--install-types", "--non-interactive"]

--- a/README.md
+++ b/README.md
@@ -65,6 +65,15 @@ For complete API documentation, visit [docs.bondmcp.com](https://docs.bondmcp.co
 
 See the [examples](https://github.com/bondmcp/mcp/tree/main/examples) directory for integration examples and use cases.
 
+## Development Setup
+
+This project uses [pre-commit](https://pre-commit.com) to run formatting and linting tools. After installing the development dependencies, install the pre-commit hooks:
+
+```bash
+pip install -e .[dev]
+pre-commit install
+```
+
 ## Support
 
 - 📖 [Documentation](https://docs.bondmcp.com)


### PR DESCRIPTION
## Summary
- set up pre-commit with black, isort, flake8 and mypy
- document development setup including `pre-commit install`
- run pre-commit in CI workflows

## Testing
- `pip install -q pre-commit black isort flake8 mypy` *(fails: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_b_684613028e548332b3e1403adbd61274