### PR TITLE
Add OpenAPI spec for all endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,15 @@ POST /api/v1/analyze
 ```
 Analyze health data and receive insights.
 
-For complete API documentation, visit [docs.bondmcp.com](https://docs.bondmcp.com)
+For complete API documentation, visit [docs.bondmcp.com](https://docs.bondmcp.com).
+
+The full OpenAPI specification for all endpoints is provided in
+[`spec/openapi.yaml`](spec/openapi.yaml). You can generate client SDKs from the
+specification using [OpenAPI Generator](https://openapi-generator.tech):
+
+```bash
+openapi-generator-cli generate -i spec/openapi.yaml -g python -o sdks/python
+```
 
 ## SDKs
 

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1,0 +1,329 @@
+openapi: 3.0.2
+info:
+  title: BondMCP API
+  version: "1.0.0"
+  description: |
+    OpenAPI specification for the BondMCP healthcare API.
+servers:
+  - url: https://api.bondmcp.com
+    description: Production
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-Key
+  schemas:
+    HealthStatus:
+      type: object
+      properties:
+        status:
+          type: string
+        version:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        environment:
+          type: string
+        services:
+          type: object
+    AskRequest:
+      type: object
+      properties:
+        message:
+          type: string
+        context:
+          type: string
+      required:
+        - message
+    AskResponse:
+      type: object
+      properties:
+        request_id:
+          type: string
+        answer:
+          type: string
+        sources:
+          type: array
+          items:
+            type: object
+paths:
+  /api/v1/health:
+    get:
+      summary: Health check
+      description: Returns API status.
+      responses:
+        '200':
+          description: Health status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthStatus'
+  /api/v1/ask:
+    post:
+      summary: Health question answering
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AskRequest'
+      responses:
+        '200':
+          description: Answer
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AskResponse'
+  /api/v1/orchestrator/multi-llm:
+    post:
+      summary: Run multi-model consensus
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                query:
+                  type: string
+                context:
+                  type: string
+      responses:
+        '200':
+          description: Consensus response
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/v1/labs/interpret:
+    post:
+      summary: Interpret lab results
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                lab_results:
+                  type: object
+      responses:
+        '200':
+          description: Lab interpretation
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/v1/health-data/analyze:
+    post:
+      summary: Analyze health data
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data_type:
+                  type: string
+                data:
+                  type: array
+                  items:
+                    type: object
+      responses:
+        '200':
+          description: Health data analysis
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/v1/supplement/recommend:
+    post:
+      summary: Get supplement recommendations
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                goals:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '200':
+          description: Supplement recommendations
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/v1/import/oura:
+    post:
+      summary: Import Oura Ring data
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                user_id:
+                  type: string
+                data:
+                  type: array
+                  items:
+                    type: object
+      responses:
+        '200':
+          description: Import result
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/v1/import/labs/csv:
+    post:
+      summary: Import CSV lab results
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                user_id:
+                  type: string
+      responses:
+        '200':
+          description: Import result
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/v1/keys:
+    get:
+      summary: List API keys
+      security:
+        - ApiKeyAuth: []
+      responses:
+        '200':
+          description: API keys
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  api_keys:
+                    type: array
+                    items:
+                      type: object
+    post:
+      summary: Create API key
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+  /api/v1/keys/{key_id}:
+    delete:
+      summary: Revoke API key
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - in: path
+          name: key_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Key revoked
+  /api/v1/insights/generate:
+    post:
+      summary: Generate health insights
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        '200':
+          description: Generated insights
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/v1/insights/history/{user_id}:
+    get:
+      summary: Get insights history
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - in: path
+          name: user_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Insights history
+          content:
+            application/json:
+              schema:
+                type: object
+  /api/v1/insights/{insight_id}:
+    get:
+      summary: Get insight details
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - in: path
+          name: insight_id
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Insight
+          content:
+            application/json:
+              schema:
+                type: object


### PR DESCRIPTION
## Summary
- document all API endpoints in a new `spec/openapi.yaml`
- reference the OpenAPI spec in the README with instructions to generate SDKs from it

## Testing
- `pre-commit` *(fails: not installed)*


------
https://chatgpt.com/codex/tasks/task_b_684613014bf083328243df53a0d7ac30