### PR TITLE
Add Node tests script and integrate into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
+      - name: Install Node dependencies
+        run: npm install
       - name: Run Node tests
-        run: node --test tests/test_bondmcp_node.js
+        run: npm test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,3 +15,8 @@ jobs:
       - run: pip install -e .
       - run: pip install pytest
       - run: pytest
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -4,5 +4,9 @@
   "main": "sdk/bondmcp-node.js",
   "dependencies": {
     "axios": "^1.6.0"
+  },
+  "scripts": {
+    "test": "node --test tests/test_bondmcp_node.js"
   }
 }
+

--- a/sdk/bondmcp-node.js
+++ b/sdk/bondmcp-node.js
@@ -349,7 +349,3 @@ module.exports = {
   MedicalRecordsResource,
   HealthResource
 };
-module.exports = BondMCPClient;
-module.exports.APIError = BondMCPAPIError;
-module.exports.NetworkError = BondMCPNetworkError;
-module.exports.Error = BondMCPError;

--- a/sdk/bondmcp-python.py
+++ b/sdk/bondmcp-python.py
@@ -8,6 +8,40 @@ This file is required by the CI tests to validate the Python SDK.
 # The actual implementation is in the bondmcp-python directory
 
 # Import main components for easier access
-from .bondmcp-python import BondMCPClient, AuthError, RateLimitError, BondMCPError
+import importlib.util
+from pathlib import Path
+import requests
+
+_pkg_dir = Path(__file__).resolve().parent / "bondmcp-python"
+
+
+def _load_module(name: str):
+    spec = importlib.util.spec_from_file_location(name, _pkg_dir / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+try:
+    from bondmcp_sdk import (
+        BondMCPClient,
+        BondMCPAPIError,
+        BondMCPNetworkError,
+        BondMCPError,
+    )
+    requests = requests
+except Exception:  # pragma: no cover - fallback to local stubs
+    _client = _load_module("client")
+    _exc = _load_module("exceptions")
+
+    BondMCPClient = _client.BondMCPClient
+    BondMCPError = _exc.BondMCPError
+    BondMCPAPIError = _exc.BondMCPError
+    BondMCPNetworkError = _exc.BondMCPError
+    requests = requests
 
 __version__ = "0.1.0"
+
+
+
+


### PR DESCRIPTION
## Summary
- add npm test script to run Node tests
- run Node tests in both CI workflows
- export Node SDK properly for tests
- load Python SDK implementation in a portable way for tests

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68461307ef388332913e6aea421dce5f