### PR TITLE
Add Dockerfile and instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir .[cli]
+ENTRYPOINT ["bondmcp"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ const response = await client.ask({
 console.log(response.answer);
 ```
 
+### Docker Usage
+
+Build the image and run the CLI without installing Python locally:
+
+```bash
+docker build -t bondmcp-cli .
+docker run --rm -e BONDMCP_PUBLIC_API_KEY=YOUR_KEY bondmcp-cli ask "What are the symptoms of high blood pressure?"
+```
+
+
 ## Features
 
 - 🏥 **Healthcare-Optimized**: Built specifically for medical and health applications


### PR DESCRIPTION
## Summary
- add Dockerfile exposing CLI
- document how to build and run the Docker image

## Testing
- `pytest -q` *(fails: SyntaxError in sdk/bondmcp-python.py)*

------
https://chatgpt.com/codex/tasks/task_b_6846130465f083329c2122aa08a81663