### PR TITLE
Switch auth header to X-API-Key

### DIFF
--- a/MCP_DIRECTORY_REGISTRATION.md
+++ b/MCP_DIRECTORY_REGISTRATION.md
@@ -130,7 +130,7 @@ def mcp_configuration():
         "auth": {
             "type": "api_key",
             "location": "header",
-            "key": "Authorization"
+            "key": "X-API-Key"
         },
         "servers": [
             {
@@ -240,7 +240,7 @@ lab_data = {
     }
 }
 
-headers = {"Authorization": "Bearer YOUR_API_KEY"}
+headers = {"X-API-Key": "YOUR_API_KEY"}
 response = requests.post(
     "https://api.bondmcp.com/mcp/servers/lab-results/request",
     json={

--- a/bondmcp.postman_collection.json
+++ b/bondmcp.postman_collection.json
@@ -61,8 +61,8 @@
                 "value": "application/json"
               },
               {
-                "key": "Authorization",
-                "value": "Bearer {{token}}"
+                "key": "X-API-Key",
+                "value": "{{token}}"
               }
             ],
             "body": {
@@ -87,8 +87,8 @@
                     "value": "application/json"
                   },
                   {
-                    "key": "Authorization",
-                    "value": "Bearer {{token}}"
+                    "key": "X-API-Key",
+                    "value": "{{token}}"
                   }
                 ],
                 "body": {
@@ -130,8 +130,8 @@
                 "value": "application/json"
               },
               {
-                "key": "Authorization",
-                "value": "Bearer {{token}}"
+                "key": "X-API-Key",
+                "value": "{{token}}"
               }
             ],
             "body": {
@@ -156,8 +156,8 @@
                     "value": "application/json"
                   },
                   {
-                    "key": "Authorization",
-                    "value": "Bearer {{token}}"
+                    "key": "X-API-Key",
+                    "value": "{{token}}"
                   }
                 ],
                 "body": {
@@ -194,8 +194,8 @@
                 "value": "application/json"
               },
               {
-                "key": "Authorization",
-                "value": "Bearer {{token}}"
+                "key": "X-API-Key",
+                "value": "{{token}}"
               }
             ],
             "body": {
@@ -220,8 +220,8 @@
                     "value": "application/json"
                   },
                   {
-                    "key": "Authorization",
-                    "value": "Bearer {{token}}"
+                    "key": "X-API-Key",
+                    "value": "{{token}}"
                   }
                 ],
                 "body": {
@@ -263,8 +263,8 @@
                 "value": "application/json"
               },
               {
-                "key": "Authorization",
-                "value": "Bearer {{token}}"
+                "key": "X-API-Key",
+                "value": "{{token}}"
               }
             ],
             "body": {
@@ -289,8 +289,8 @@
                     "value": "application/json"
                   },
                   {
-                    "key": "Authorization",
-                    "value": "Bearer {{token}}"
+                    "key": "X-API-Key",
+                    "value": "{{token}}"
                   }
                 ],
                 "body": {
@@ -332,8 +332,8 @@
                 "value": "application/json"
               },
               {
-                "key": "Authorization",
-                "value": "Bearer {{token}}"
+                "key": "X-API-Key",
+                "value": "{{token}}"
               }
             ],
             "body": {
@@ -358,8 +358,8 @@
                     "value": "application/json"
                   },
                   {
-                    "key": "Authorization",
-                    "value": "Bearer {{token}}"
+                    "key": "X-API-Key",
+                    "value": "{{token}}"
                   }
                 ],
                 "body": {
@@ -401,8 +401,8 @@
                 "value": "application/json"
               },
               {
-                "key": "Authorization",
-                "value": "Bearer {{token}}"
+                "key": "X-API-Key",
+                "value": "{{token}}"
               }
             ],
             "body": {
@@ -427,8 +427,8 @@
                     "value": "application/json"
                   },
                   {
-                    "key": "Authorization",
-                    "value": "Bearer {{token}}"
+                    "key": "X-API-Key",
+                    "value": "{{token}}"
                   }
                 ],
                 "body": {

--- a/bondmcp_cli/cli.py
+++ b/bondmcp_cli/cli.py
@@ -44,6 +44,7 @@ def cli():
     """BondMCP Public API CLI"""
     pass
 
+
 @cli.command()
 @click.argument("query")
 def ask(query):
@@ -54,7 +55,7 @@ def ask(query):
     resp = requests.post(
         url,
         json={"query": query},
-        headers={"Authorization": f"Bearer {api_key}"},
+        headers={"X-API-Key": api_key},
     )
     if resp.status_code == 200:
         Console().print(resp.json().get("response"))
@@ -80,7 +81,7 @@ def labs_interpret(labs, context):
     if context:
         payload["patient_context"] = json.loads(Path(context).read_text())
 
-    resp = requests.post(url, json=payload, headers={"Authorization": f"Bearer {api_key}"})
+    resp = requests.post(url, json=payload, headers={"X-API-Key": api_key})
     if resp.status_code == 200:
         Console().print_json(data=resp.json())
     else:
@@ -126,13 +127,17 @@ def supplement_recommend(
     if labs:
         payload["current_labs"] = json.loads(Path(labs).read_text())
     if current_supplements:
-        payload["current_supplements"] = json.loads(Path(current_supplements).read_text())
+        payload["current_supplements"] = json.loads(
+            Path(current_supplements).read_text()
+        )
     if dietary_restrictions:
-        payload["dietary_restrictions"] = json.loads(Path(dietary_restrictions).read_text())
+        payload["dietary_restrictions"] = json.loads(
+            Path(dietary_restrictions).read_text()
+        )
     if context:
         payload["patient_context"] = json.loads(Path(context).read_text())
 
-    resp = requests.post(url, json=payload, headers={"Authorization": f"Bearer {api_key}"})
+    resp = requests.post(url, json=payload, headers={"X-API-Key": api_key})
     if resp.status_code == 200:
         Console().print_json(data=resp.json())
     else:
@@ -146,12 +151,13 @@ def health():
     api_key = get_api_key()
     base_url = os.getenv("BONDMCP_PUBLIC_API_BASE_URL", "https://api.bondmcp.com")
     url = f"{base_url}/health"
-    resp = requests.get(url, headers={"Authorization": f"Bearer {api_key}"})
+    resp = requests.get(url, headers={"X-API-Key": api_key})
     if resp.status_code == 200:
         Console().print_json(data=resp.json())
     else:
         Console().print(f"API error {resp.status_code}: {resp.text}")
         raise SystemExit(1)
+
 
 if __name__ == "__main__":
     cli()

--- a/bondmcp_sdk/client.py
+++ b/bondmcp_sdk/client.py
@@ -1,7 +1,8 @@
 # import bondmcp
-import requests
 import json
-from typing import Dict, List, Optional, Union, Any
+from typing import Any, Dict, List, Optional, Union
+
+import requests
 
 # Disclaimer: This SDK is provided for informational purposes only and does not
 # constitute medical advice.
@@ -67,7 +68,7 @@ class BondMCPClient:
         """
         url = f"{self.base_url}{path}"
         headers = {
-            "Authorization": f"Bearer {self.api_key}",
+            "X-API-Key": self.api_key,
             "Content-Type": "application/json",
             "Accept": "application/json",
             "User-Agent": "bondmcp-python/1.0.0",
@@ -352,7 +353,10 @@ class APIKeysResource:
         return self.client.request("post", "/api-keys", data=data)
 
     def update(
-        self, key_id: str, name: Optional[str] = None, scopes: Optional[List[str]] = None
+        self,
+        key_id: str,
+        name: Optional[str] = None,
+        scopes: Optional[List[str]] = None,
     ) -> Dict:
         """Update an existing API key."""
         data: Dict[str, Any] = {}

--- a/sdk/bondmcp-node.js
+++ b/sdk/bondmcp-node.js
@@ -13,7 +13,7 @@ class BondMCPClient {
       baseURL: this.baseURL,
       timeout: this.timeout,
       headers: {
-        'Authorization': `Bearer ${this.apiKey}`,
+        'X-API-Key': this.apiKey,
         'Content-Type': 'application/json',
         'Accept': 'application/json',
         'User-Agent': 'bondmcp-node/1.0.0'

--- a/sdk/bondmcp-python.py
+++ b/sdk/bondmcp-python.py
@@ -3,10 +3,13 @@
 import importlib.util
 from pathlib import Path
 
+import requests
+
 __version__ = "0.1.0"
 
 # Define path to local modules (fallback)
-_pkg_dir = Path(__file__).resolve().parent / "bondmcp-python"
+_pkg_dir = Path(__file__).resolve().parent / "bondmcp_python"
+
 
 def _load_module(name: str):
     spec = importlib.util.spec_from_file_location(name, _pkg_dir / f"{name}.py")
@@ -14,11 +17,12 @@ def _load_module(name: str):
     spec.loader.exec_module(module)
     return module
 
+
 try:
     # Primary import from installed package
     from bondmcp_sdk import (
-        BondMCPClient,
         BondMCPAPIError,
+        BondMCPClient,
         BondMCPError,
         BondMCPNetworkError,
     )
@@ -37,4 +41,5 @@ __all__ = [
     "BondMCPAPIError",
     "BondMCPError",
     "BondMCPNetworkError",
+    "requests",
 ]

--- a/tests/test_bondmcp_node.js
+++ b/tests/test_bondmcp_node.js
@@ -32,7 +32,7 @@ test('POST request builds correct options', async () => {
   const data = { foo: 'bar' };
   const res = await client.request('post', '/test', data);
   assert.strictEqual(captured.config.baseURL, 'http://example');
-  assert.strictEqual(captured.config.headers.Authorization, 'Bearer KEY');
+  assert.strictEqual(captured.config.headers['X-API-Key'], 'KEY');
   assert.strictEqual(captured.request.method, 'post');
   assert.strictEqual(captured.request.url, '/test');
   assert.deepStrictEqual(captured.request.data, data);

--- a/tests/test_bondmcp_python.py
+++ b/tests/test_bondmcp_python.py
@@ -1,7 +1,8 @@
-import pytest
 import sys
 import types
 from pathlib import Path
+
+import pytest
 
 # Ensure project root is on sys.path
 ROOT = Path(__file__).resolve().parents[1]
@@ -12,16 +13,16 @@ if str(SDK_DIR) not in sys.path:
     sys.path.insert(0, str(SDK_DIR))
 
 # Provide a stub requests module if not installed
-if 'requests' not in sys.modules:
-    requests_stub = types.ModuleType('requests')
-    sys.modules['requests'] = requests_stub
-import requests
-
+if "requests" not in sys.modules:
+    requests_stub = types.ModuleType("requests")
+    sys.modules["requests"] = requests_stub
 import importlib.util
 
+import requests
+
 spec = importlib.util.spec_from_file_location(
-    'sdk.bondmcp_python_stub',
-    ROOT / 'sdk' / 'bondmcp-python.py',
+    "sdk.bondmcp_python_stub",
+    ROOT / "sdk" / "bondmcp-python.py",
 )
 bondmcp_python = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(bondmcp_python)
@@ -44,39 +45,39 @@ def test_request_get(monkeypatch):
     captured = {}
 
     def fake_get(url, headers=None, params=None, timeout=None):
-        captured['url'] = url
-        captured['headers'] = headers
-        captured['params'] = params
-        captured['timeout'] = timeout
-        return DummyResp({'ok': True})
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["params"] = params
+        captured["timeout"] = timeout
+        return DummyResp({"ok": True})
 
-    monkeypatch.setattr(requests, 'get', fake_get, raising=False)
+    monkeypatch.setattr(requests, "get", fake_get, raising=False)
 
-    client = BondMCPClient('KEY', base_url='http://example')
-    resp = client.request('get', '/foo', params={'a': 1})
+    client = BondMCPClient("KEY", base_url="http://example")
+    resp = client.request("get", "/foo", params={"a": 1})
 
-    assert resp == {'ok': True}
-    assert captured['url'] == 'http://example/foo'
-    assert captured['params'] == {'a': 1}
-    assert captured['headers']['Authorization'] == 'Bearer KEY'
+    assert resp == {"ok": True}
+    assert captured["url"] == "http://example/foo"
+    assert captured["params"] == {"a": 1}
+    assert captured["headers"]["X-API-Key"] == "KEY"
 
 
 def test_request_post(monkeypatch):
     captured = {}
 
     def fake_post(url, headers=None, json=None, timeout=None):
-        captured['url'] = url
-        captured['headers'] = headers
-        captured['json'] = json
-        captured['timeout'] = timeout
-        return DummyResp({'ok': True})
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["json"] = json
+        captured["timeout"] = timeout
+        return DummyResp({"ok": True})
 
-    monkeypatch.setattr(requests, 'post', fake_post, raising=False)
+    monkeypatch.setattr(requests, "post", fake_post, raising=False)
 
-    client = BondMCPClient('KEY', base_url='http://example')
-    resp = client.request('post', '/bar', data={'x': 2})
+    client = BondMCPClient("KEY", base_url="http://example")
+    resp = client.request("post", "/bar", data={"x": 2})
 
-    assert resp == {'ok': True}
-    assert captured['url'] == 'http://example/bar'
-    assert captured['json'] == {'x': 2}
-    assert captured['headers']['Authorization'] == 'Bearer KEY'
+    assert resp == {"ok": True}
+    assert captured["url"] == "http://example/bar"
+    assert captured["json"] == {"x": 2}
+    assert captured["headers"]["X-API-Key"] == "KEY"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
-from click.testing import CliRunner
 import sys
 import types
+
+from click.testing import CliRunner
 
 if "requests" not in sys.modules:
     requests_stub = types.ModuleType("requests")
@@ -10,20 +11,24 @@ if "requests" not in sys.modules:
 if "rich" not in sys.modules:
     rich_stub = types.ModuleType("rich")
     console_mod = types.ModuleType("rich.console")
+
     class DummyConsole:
         def print(self, *args, **kwargs):
             print(*args)
+
     console_mod.Console = DummyConsole
     sys.modules["rich"] = rich_stub
     sys.modules["rich.console"] = console_mod
 
 from bondmcp_cli.cli import cli
 
+
 class DummyResponse:
     def __init__(self, status_code, json_data=None, text=""):
         self.status_code = status_code
         self._json_data = json_data or {}
         self.text = text
+
     def json(self):
         return self._json_data
 
@@ -31,8 +36,9 @@ class DummyResponse:
 def test_ask_success(monkeypatch):
     def fake_post(url, json, headers):
         assert json == {"query": "hello"}
-        assert "Authorization" in headers
+        assert "X-API-Key" in headers
         return DummyResponse(200, {"response": "hi"})
+
     monkeypatch.setattr("bondmcp_cli.cli.requests.post", fake_post)
     runner = CliRunner()
     env = {
@@ -47,20 +53,24 @@ def test_ask_success(monkeypatch):
 def test_ask_error(monkeypatch):
     def fake_post(url, json, headers):
         return DummyResponse(500, text="bad")
+
     monkeypatch.setattr("bondmcp_cli.cli.requests.post", fake_post)
     runner = CliRunner()
     env = {"BONDMCP_PUBLIC_API_KEY": "token"}
     result = runner.invoke(cli, ["ask", "hello"], env=env)
     assert result.exit_code != 0
     assert "API error 500" in result.output
+
+
 import os
 import sys
 from pathlib import Path
+
 from click.testing import CliRunner
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from bondmcp_cli.cli import cli
 import bondmcp_cli.cli as cli_module
+from bondmcp_cli.cli import cli
 
 
 def test_ask_success(monkeypatch):


### PR DESCRIPTION
## Summary
- send API key via `X-API-Key` instead of `Authorization`
- update CLI and Node SDK to use new header
- adjust Python and Node tests for the new header
- fix local Python stub used in tests
- update docs and Postman collection

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68472990e8508332a607014efdb2327b