### PR TITLE
Add error handling docs

### DIFF
--- a/docs/sdk-overview.md
+++ b/docs/sdk-overview.md
@@ -122,6 +122,59 @@ All SDKs provide consistent error handling patterns. Errors are categorized into
 
 Each SDK follows the idiomatic error handling pattern for its language.
 
+### Python Example
+
+```python
+from bondmcp import BondMCPClient, BondMCPAPIError, BondMCPNetworkError
+
+client = BondMCPClient(api_key="your_api_key")
+
+try:
+    client.ask("What are the symptoms of high blood pressure?")
+except BondMCPAPIError as e:
+    print(f"API error {e.status_code} ({e.code}): {e}")
+except BondMCPNetworkError as e:
+    print(f"Network error: {e}")
+```
+
+Sample output when the API key is invalid:
+
+```text
+API error 401 (authentication_error): Invalid API key
+```
+
+Sample output for a network issue:
+
+```text
+Network error: Connection timed out
+```
+
+### JavaScript Example
+
+```javascript
+import { BondMCPClient, BondMCPAPIError, BondMCPNetworkError } from 'bondmcp';
+
+const client = new BondMCPClient({ apiKey: 'your_api_key' });
+
+try {
+  await client.ask('What are the symptoms of high blood pressure?');
+} catch (error) {
+  if (error instanceof BondMCPAPIError) {
+    console.log(`API error ${error.statusCode} (${error.code}): ${error.message}`);
+  } else if (error instanceof BondMCPNetworkError) {
+    console.log('Network error:', error.message);
+  } else {
+    console.log('Unexpected error:', error);
+  }
+}
+```
+
+Sample output for a missing endpoint:
+
+```text
+API error 404 (not_found): Endpoint not found
+```
+
 ## Pagination
 
 For endpoints that return large collections of data, our SDKs provide pagination helpers:

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -133,7 +133,13 @@ info = client.supplement.get_info("Vitamin D3")
 The SDK provides comprehensive error handling:
 
 ```python
-from bondmcp.exceptions import BondMCPError, AuthError, RateLimitError
+from bondmcp.exceptions import (
+    BondMCPAPIError,
+    BondMCPNetworkError,
+    BondMCPError,
+    AuthError,
+    RateLimitError,
+)
 
 try:
     response = client.ask("What are the symptoms of high blood pressure?")
@@ -141,8 +147,24 @@ except AuthError:
     print("Authentication failed. Check your API key.")
 except RateLimitError:
     print("Rate limit exceeded. Please try again later.")
+except BondMCPAPIError as e:
+    print(f"API error {e.status_code} ({e.code}): {e}")
+except BondMCPNetworkError:
+    print("Network error, please retry later.")
 except BondMCPError as e:
-    print(f"An error occurred: {e}")
+    print(f"An unexpected error occurred: {e}")
+```
+
+Example output for an invalid key:
+
+```text
+API error 401 (authentication_error): Invalid API key
+```
+
+Example output when the network is unavailable:
+
+```text
+Network error, please retry later.
 ```
 
 ## Pagination


### PR DESCRIPTION
## Summary
- add Python and JS error handling examples with `BondMCPAPIError` and `BondMCPNetworkError`
- update Python SDK README with detailed error handling snippet and sample outputs

## Testing
- `pre-commit` *(fails: not run, documentation only)*

------
https://chatgpt.com/codex/tasks/task_b_68472995b94483328ec806fb708e7816