### PR TITLE
Fix duplicate CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
-from click.testing import CliRunner
 import sys
 import types
+
+from click.testing import CliRunner
 
 if "requests" not in sys.modules:
     requests_stub = types.ModuleType("requests")
@@ -10,20 +11,24 @@ if "requests" not in sys.modules:
 if "rich" not in sys.modules:
     rich_stub = types.ModuleType("rich")
     console_mod = types.ModuleType("rich.console")
+
     class DummyConsole:
         def print(self, *args, **kwargs):
             print(*args)
+
     console_mod.Console = DummyConsole
     sys.modules["rich"] = rich_stub
     sys.modules["rich.console"] = console_mod
 
 from bondmcp_cli.cli import cli
 
+
 class DummyResponse:
     def __init__(self, status_code, json_data=None, text=""):
         self.status_code = status_code
         self._json_data = json_data or {}
         self.text = text
+
     def json(self):
         return self._json_data
 
@@ -33,6 +38,7 @@ def test_ask_success(monkeypatch):
         assert json == {"query": "hello"}
         assert "Authorization" in headers
         return DummyResponse(200, {"response": "hi"})
+
     monkeypatch.setattr("bondmcp_cli.cli.requests.post", fake_post)
     runner = CliRunner()
     env = {
@@ -47,54 +53,10 @@ def test_ask_success(monkeypatch):
 def test_ask_error(monkeypatch):
     def fake_post(url, json, headers):
         return DummyResponse(500, text="bad")
+
     monkeypatch.setattr("bondmcp_cli.cli.requests.post", fake_post)
     runner = CliRunner()
     env = {"BONDMCP_PUBLIC_API_KEY": "token"}
     result = runner.invoke(cli, ["ask", "hello"], env=env)
     assert result.exit_code != 0
     assert "API error 500" in result.output
-import os
-import sys
-from pathlib import Path
-from click.testing import CliRunner
-
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from bondmcp_cli.cli import cli
-import bondmcp_cli.cli as cli_module
-
-
-def test_ask_success(monkeypatch):
-    runner = CliRunner()
-
-    def fake_post(url, json=None, headers=None):
-        class Resp:
-            status_code = 200
-
-            def json(self):
-                return {"response": "hello"}
-
-        return Resp()
-
-    monkeypatch.setattr(cli_module.requests, "post", fake_post)
-    result = runner.invoke(cli, ["ask", "hi"], env={"BONDMCP_PUBLIC_API_KEY": "k"})
-    assert result.exit_code == 0
-    assert "hello" in result.output
-
-
-def test_ask_error(monkeypatch):
-    runner = CliRunner()
-
-    def fake_post(url, json=None, headers=None):
-        class Resp:
-            status_code = 400
-            text = "bad"
-
-            def json(self):
-                return {}
-
-        return Resp()
-
-    monkeypatch.setattr(cli_module.requests, "post", fake_post)
-    result = runner.invoke(cli, ["ask", "hi"], env={"BONDMCP_PUBLIC_API_KEY": "k"})
-    assert result.exit_code == 1
-    assert "API error 400: bad" in result.output


### PR DESCRIPTION
## Summary
- remove redundant CLI tests
- keep a single test pair for CLI success and error cases

## Testing
- `black --check tests/test_cli.py`
- `isort --check-only tests/test_cli.py`
- `node --test tests/test_bondmcp_node.js`
- `pytest` *(fails: AttributeError: module 'sdk.bondmcp_python_stub' has no attribute 'requests')*
- `flake8 tests/test_cli.py` *(fails: command not found)*
- `mypy tests/test_cli.py`

------
https://chatgpt.com/codex/tasks/task_b_68472994152c8332876e67ecae524b92