### PR TITLE
Add 429 retry handling to client

### DIFF
--- a/bondmcp_sdk/client.py
+++ b/bondmcp_sdk/client.py
@@ -1,7 +1,9 @@
 # import bondmcp
-import requests
 import json
-from typing import Dict, List, Optional, Union, Any
+import time
+from typing import Any, Dict, List, Optional, Union
+
+import requests
 
 # Disclaimer: This SDK is provided for informational purposes only and does not
 # constitute medical advice.
@@ -13,6 +15,8 @@ class BondMCPClient:
         api_key: str,
         base_url: str = "https://api.bondmcp.com/api",
         timeout: int = 30,
+        max_retries: int = 0,
+        retry_delay: float = 1.0,
     ):
         """
         Initialize the BondMCP API client.
@@ -21,10 +25,14 @@ class BondMCPClient:
             api_key: Your BondMCP API key
             base_url: The base URL for the BondMCP API
             timeout: Request timeout in seconds
+            max_retries: Number of retry attempts for rate limited requests
+            retry_delay: Base delay in seconds before retries (exponential backoff)
         """
         self.api_key = api_key
         self.base_url = base_url
         self.timeout = timeout
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
 
         # Initialize API resources
         self.health = HealthResource(self)
@@ -73,56 +81,66 @@ class BondMCPClient:
             "User-Agent": "bondmcp-python/1.0.0",
         }
 
-        try:
-            if method.lower() == "get":
-                response = requests.get(
-                    url, headers=headers, params=params, timeout=self.timeout
-                )
-            elif method.lower() == "post":
-                response = requests.post(
-                    url, headers=headers, json=data, timeout=self.timeout
-                )
-            elif method.lower() == "put":
-                response = requests.put(
-                    url, headers=headers, json=data, timeout=self.timeout
-                )
-            elif method.lower() == "delete":
-                response = requests.delete(
-                    url, headers=headers, json=data, timeout=self.timeout
-                )
-            else:
-                raise BondMCPError(f"Unsupported HTTP method: {method}")
-
-            response.raise_for_status()
-            return response.json()
-
-        except requests.exceptions.HTTPError as e:
+        for attempt in range(self.max_retries + 1):
             try:
-                error_data = e.response.json()
-                error_message = error_data.get("error", {}).get(
-                    "message", "API request failed"
-                )
-                error_code = error_data.get("error", {}).get("code", "api_error")
-                error_details = error_data.get("error", {}).get("details", {})
-                raise BondMCPAPIError(
-                    error_message, e.response.status_code, error_code, error_details
-                )
-            except (ValueError, KeyError):
-                raise BondMCPAPIError(
-                    str(e), e.response.status_code if hasattr(e, "response") else 0
-                )
+                if method.lower() == "get":
+                    response = requests.get(
+                        url, headers=headers, params=params, timeout=self.timeout
+                    )
+                elif method.lower() == "post":
+                    response = requests.post(
+                        url, headers=headers, json=data, timeout=self.timeout
+                    )
+                elif method.lower() == "put":
+                    response = requests.put(
+                        url, headers=headers, json=data, timeout=self.timeout
+                    )
+                elif method.lower() == "delete":
+                    response = requests.delete(
+                        url, headers=headers, json=data, timeout=self.timeout
+                    )
+                else:
+                    raise BondMCPError(f"Unsupported HTTP method: {method}")
 
-        except requests.exceptions.ConnectionError:
-            raise BondMCPNetworkError("Network error: Failed to connect to API")
+                response.raise_for_status()
+                return response.json()
+            except requests.exceptions.HTTPError as e:
+                status = e.response.status_code if hasattr(e, "response") else 0
+                if status == 429 and attempt < self.max_retries:
+                    retry_after = (
+                        e.response.headers.get("Retry-After") if e.response else None
+                    )
+                    delay = (
+                        float(retry_after)
+                        if retry_after
+                        else self.retry_delay * (2**attempt)
+                    )
+                    time.sleep(delay)
+                    continue
+                try:
+                    error_data = e.response.json()
+                    error_message = error_data.get("error", {}).get(
+                        "message", "API request failed"
+                    )
+                    error_code = error_data.get("error", {}).get("code", "api_error")
+                    error_details = error_data.get("error", {}).get("details", {})
+                    raise BondMCPAPIError(
+                        error_message, e.response.status_code, error_code, error_details
+                    )
+                except (ValueError, KeyError):
+                    raise BondMCPAPIError(
+                        str(e), e.response.status_code if hasattr(e, "response") else 0
+                    )
+            except requests.exceptions.ConnectionError:
+                raise BondMCPNetworkError("Network error: Failed to connect to API")
+            except requests.exceptions.Timeout:
+                raise BondMCPNetworkError("Network error: Request timed out")
+            except requests.exceptions.RequestException as e:
+                raise BondMCPNetworkError(f"Network error: {str(e)}")
+            except Exception as e:
+                raise BondMCPError(f"Unexpected error: {str(e)}")
 
-        except requests.exceptions.Timeout:
-            raise BondMCPNetworkError("Network error: Request timed out")
-
-        except requests.exceptions.RequestException as e:
-            raise BondMCPNetworkError(f"Network error: {str(e)}")
-
-        except Exception as e:
-            raise BondMCPError(f"Unexpected error: {str(e)}")
+        raise BondMCPError("Exceeded maximum retry attempts")
 
 
 class HealthResource:
@@ -352,7 +370,10 @@ class APIKeysResource:
         return self.client.request("post", "/api-keys", data=data)
 
     def update(
-        self, key_id: str, name: Optional[str] = None, scopes: Optional[List[str]] = None
+        self,
+        key_id: str,
+        name: Optional[str] = None,
+        scopes: Optional[List[str]] = None,
     ) -> Dict:
         """Update an existing API key."""
         data: Dict[str, Any] = {}

--- a/docs/api-reference/rate-limiting.md
+++ b/docs/api-reference/rate-limiting.md
@@ -149,6 +149,10 @@ client = BondMCPClient(
 )
 ```
 
+When the API responds with `429 Too Many Requests`, the client waits for
+`retry_delay * 2^attempt` seconds (or the `Retry-After` header if provided)
+before retrying up to `max_retries` times.
+
 For more information on SDK configuration, see the [SDK Integration](../sdks/) guides.
 
 ## Pay-Per-Call Pricing

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -172,6 +172,9 @@ client = BondMCPClient(
     retry_delay=2  # Delay between retries in seconds
 )
 
+# Requests that return a 429 status code will automatically be retried
+# using exponential backoff based on these settings.
+
 # Custom HTTP client
 import httpx
 custom_client = httpx.Client(timeout=30)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,14 +1,17 @@
-import json
 import importlib.util
-from pathlib import Path
+import json
 import sys
-import requests
+from pathlib import Path
+
 import pytest
+import requests
 
 ROOT = Path(__file__).resolve().parent.parent
 SDK_DIR = ROOT / "sdk"
 if str(SDK_DIR) not in sys.path:
     sys.path.insert(0, str(SDK_DIR))
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 spec = importlib.util.spec_from_file_location(
     "sdk.bondmcp_python_stub",
     SDK_DIR / "bondmcp-python.py",
@@ -22,6 +25,7 @@ class DummyResponse:
         self.status_code = status_code
         self._payload = payload
         self.text = json.dumps(payload)
+        self.headers = {}
 
     def json(self):
         return self._payload
@@ -42,7 +46,7 @@ def test_request_success(monkeypatch):
         calls["url"] = url
         return DummyResponse(200, {"ok": True})
 
-    monkeypatch.setattr(bondmcp.requests, "get", fake_get)
+    monkeypatch.setattr(requests, "get", fake_get, raising=False)
     result = client.request("get", "/test")
     assert result == {"ok": True}
     assert calls["url"] == "https://example.com/test"
@@ -54,7 +58,7 @@ def test_request_http_error(monkeypatch):
     def fake_get(url, headers=None, params=None, timeout=None):
         return DummyResponse(404, {"error": {"message": "bad", "code": "404"}})
 
-    monkeypatch.setattr(bondmcp.requests, "get", fake_get)
+    monkeypatch.setattr(requests, "get", fake_get, raising=False)
     with pytest.raises(bondmcp.BondMCPAPIError) as exc:
         client.request("get", "/test")
     assert exc.value.status_code == 404
@@ -67,6 +71,43 @@ def test_request_network_error(monkeypatch):
     def fake_get(url, headers=None, params=None, timeout=None):
         raise requests.exceptions.ConnectionError
 
-    monkeypatch.setattr(bondmcp.requests, "get", fake_get)
+    monkeypatch.setattr(requests, "get", fake_get, raising=False)
     with pytest.raises(bondmcp.BondMCPNetworkError):
         client.request("get", "/test")
+
+
+def test_request_retry_on_rate_limit(monkeypatch):
+    client = bondmcp.BondMCPClient(
+        "k", base_url="https://example.com", max_retries=2, retry_delay=0
+    )
+
+    calls = {"count": 0}
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            resp = DummyResponse(429, {"error": {"message": "limit", "code": "429"}})
+            resp.headers = {"Retry-After": "0"}
+            return resp
+        return DummyResponse(200, {"ok": True})
+
+    monkeypatch.setattr(requests, "get", fake_get, raising=False)
+    result = client.request("get", "/test")
+    assert result == {"ok": True}
+    assert calls["count"] == 2
+
+
+def test_request_retry_exhausts(monkeypatch):
+    client = bondmcp.BondMCPClient(
+        "k", base_url="https://example.com", max_retries=1, retry_delay=0
+    )
+
+    def fake_get(url, headers=None, params=None, timeout=None):
+        resp = DummyResponse(429, {"error": {"message": "limit", "code": "429"}})
+        resp.headers = {"Retry-After": "0"}
+        return resp
+
+    monkeypatch.setattr(requests, "get", fake_get, raising=False)
+    with pytest.raises(bondmcp.BondMCPAPIError) as exc:
+        client.request("get", "/test")
+    assert exc.value.status_code == 429


### PR DESCRIPTION
## Summary
- implement optional retry/backoff when the Python client receives a 429
- document the new configuration in SDK docs
- test retry behaviour in the Python client

## Testing
- `black bondmcp_sdk/client.py tests/test_client.py`
- `isort bondmcp_sdk/client.py tests/test_client.py`
- `flake8 bondmcp_sdk/client.py tests/test_client.py` *(fails: command not found)*
- `mypy bondmcp_sdk/client.py tests/test_client.py` *(fails: missing stubs and typing errors)*
- `pytest -q`
- `node --test tests/test_bondmcp_node.js`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_b_6847299608d083329949341cdc97589e